### PR TITLE
Create custom slim playwright Dockerfile

### DIFF
--- a/compose.common.yaml
+++ b/compose.common.yaml
@@ -23,7 +23,7 @@ services:
       start_period: 1m
 
   playwright:
-    image: mcr.microsoft.com/playwright:v1.55.0-noble
+    image: neutronlul/dumbjared-playwright:latest
     command:
       [
         "sh",

--- a/playwright/Dockerfile
+++ b/playwright/Dockerfile
@@ -1,3 +1,16 @@
-FROM node:20-bookworm
+FROM node:24-bookworm-slim
 
-RUN npx -y playwright@1.56.1 install --with-deps
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    adduser pwuser
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+RUN mkdir /ms-playwright && \
+    npx -y playwright@1.55.0 install --with-deps --only-shell chromium && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /root/.npm && \
+    chmod -R 777 /ms-playwright


### PR DESCRIPTION
This pull request updates the Playwright service configuration and its Dockerfile to use a custom Docker image and optimize the container setup. The main changes focus on switching to a tailored Playwright image, updating the Node.js base image, and streamlining the installation of dependencies and browsers.

**Playwright service configuration:**

* Switched the Playwright service image in `compose.common.yaml` from the official Microsoft image to the custom `neutronlul/dumbjared-playwright:latest` image, allowing for more control over the environment.

**Dockerfile improvements:**

* Updated the base image in `playwright/Dockerfile` from `node:20-bookworm` to the slimmer and more recent `node:24-bookworm-slim`, reducing image size and improving performance.
* Added installation steps for `curl`, created a dedicated user `pwuser`, and set the `PLAYWRIGHT_BROWSERS_PATH` environment variable for better isolation and security.
* Changed Playwright installation to only include the `chromium` browser and cleaned up unnecessary files and directories to minimize the final image size.