### PR TITLE
Add coverage report option to pytest configuration

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,7 +27,7 @@ omit = [
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "config.settings"
 python_files = ["test_*.py"]
-addopts = ["--cov=api", "--cov=core", "--cov=scraper"]
+addopts = ["--cov-report=term-missing", "--cov=api", "--cov=core", "--cov=scraper"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
This pull request makes a small update to the test configuration by improving the coverage reporting output.

- Enhanced test coverage reporting by adding the `--cov-report=term-missing` option to the `addopts` setting in `pyproject.toml`, which will display lines missing coverage in the terminal output.