### PR TITLE
Fix Unfold styling

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -1,21 +1,9 @@
 from django.contrib import admin
-from . import models
+from django.apps import apps
+from unfold.admin import ModelAdmin
 
-# Register your models here.
+# Get all models from the current app
+app_models = apps.get_app_config("api").get_models()
 
-for model in [
-    models.Quizmaster,
-    models.Team,
-    models.Member,
-    models.Table,
-    models.Theme,
-    models.Round,
-    models.Glossary,
-    # models.EventType,
-    models.Venue,
-    models.Event,
-    models.Vote,
-    models.TeamEventParticipation,
-    models.MemberAttendance,
-]:
-    admin.site.register(model)
+for model in app_models:
+    admin.site.register(model, ModelAdmin)

--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -1,3 +1,24 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.admin import GroupAdmin as BaseGroupAdmin
+from django.contrib.auth.models import User, Group
 
-# Register your models here.
+from unfold.forms import AdminPasswordChangeForm, UserChangeForm, UserCreationForm
+from unfold.admin import ModelAdmin
+
+
+admin.site.unregister(User)
+admin.site.unregister(Group)
+
+
+@admin.register(User)
+class UserAdmin(BaseUserAdmin, ModelAdmin):
+    # Forms loaded from `unfold.forms`
+    form = UserChangeForm
+    add_form = UserCreationForm
+    change_password_form = AdminPasswordChangeForm
+
+
+@admin.register(Group)
+class GroupAdmin(BaseGroupAdmin, ModelAdmin):
+    pass


### PR DESCRIPTION
This pull request refactors the Django admin registration process for both the `api` and `core` apps, improving maintainability and integrating the `unfold` admin interface. The changes automate model registration for the `api` app and enhance user and group administration in the `core` app by customizing forms and admin classes.

**Admin registration automation and interface integration:**

* Automated registration of all models in the `api` app using a loop, replacing manual registration and applying the `unfold` `ModelAdmin` for a consistent interface. (`backend/api/admin.py`)

**User and group admin customization:**

* Unregistered the default `User` and `Group` models from the admin site, then re-registered them with custom admin classes that inherit from both Django's base admin classes and `unfold`'s `ModelAdmin`, enabling the use of custom forms for user management. (`backend/core/admin.py`)
* Integrated custom forms from `unfold` (`AdminPasswordChangeForm`, `UserChangeForm`, `UserCreationForm`) into the `UserAdmin` class for enhanced user management capabilities. (`backend/core/admin.py`)